### PR TITLE
BUGFIX: __hasany lookup doesn't filter properly with applied other filters

### DIFF
--- a/collectionfield/models/lookups.py
+++ b/collectionfield/models/lookups.py
@@ -66,7 +66,7 @@ class HasMany(Has):
             rhs = self.get_rhs_op(connection, rhs)
             sql_items.append('%s %s' % (lhs, rhs))
             params.extend(lhs_params + rhs_params)
-        return self.join_conditions_with.join(sql_items), params
+        return '(%s)' % self.join_conditions_with.join(sql_items), params
 
     def get_rhs_op(self, connection, rhs):
         return connection.operators['contains'] % rhs

--- a/collectionfield/tests/models.py
+++ b/collectionfield/tests/models.py
@@ -147,3 +147,18 @@ class Max10CharsStringListModel(models.Model):
 class Max5ItemsStringListModel(models.Model):
 
     values = CollectionField(max_items=5)
+
+
+class MultipleFieldsModel(models.Model):
+    
+    values = CollectionField(
+        choices=(
+            ('aaa', "AAA"),
+            ('bbb', "BBB"),
+            ('ccc', "CCC"),
+            ('ddd', "DDD"),
+        )
+    )
+    name = models.CharField(max_length=20)
+    active = models.BooleanField(default=True)
+

--- a/collectionfield/tests/tests.py
+++ b/collectionfield/tests/tests.py
@@ -20,7 +20,8 @@ from .models import (
     DecimalSetModel, DefaultDecimalSetModel, SortedDecimalListModel,
     IntegerTupleModel, DefaultIntegerTupleModel, OptionalIntegerTupleModel,
     Max10CharsStringListModel, Max5ItemsStringListModel,
-    OptionalGroupedChoiceStringListModel, OptionalGroupedChoiceIntegerListModel
+    OptionalGroupedChoiceStringListModel, OptionalGroupedChoiceIntegerListModel,
+    MultipleFieldsModel
 )
 from .forms import (
     StringSetForm, OptionalStringSetForm, IntegerListForm, DecimalTupleForm,
@@ -438,6 +439,64 @@ class HasAnyLookupTestCase(TestCase):
                 )
             ),
             []
+        )
+
+    def test_multiple_filters(self):
+        obj1 = MultipleFieldsModel.objects.create(
+            values=['Aliens', 'Starships', 'Aliens'],
+            name='Adam',
+            active=True
+        )
+        obj2 = MultipleFieldsModel.objects.create(
+            values=['Lions', 'Jungle'],
+            name='John',
+            active=False
+        )
+        obj3 = MultipleFieldsModel.objects.create(
+            values=['Pyramids', 'Aliens', 'Lions'],
+            name='Henry',
+            active=True
+        )
+        obj4 = MultipleFieldsModel.objects.create(
+            values=['Lions', 'Jungle', 'Monkeys'],
+            name='John',
+            active=True
+        )
+        obj5 = MultipleFieldsModel.objects.create(
+            values=['Jungle', 'Lions', 'Aliens'],
+            name='Kate',
+            active=True
+        )
+
+        self.assertListEqual(
+            list(
+                MultipleFieldsModel.objects.filter(
+                    values__hasany=['Aliens', 'Monkeys'],
+                    active=True
+                )
+            ),
+            [obj1, obj3, obj4, obj5]
+        )
+
+        self.assertListEqual(
+            list(
+                MultipleFieldsModel.objects.filter(
+                    values__hasany=['Lions', 'Jungle'],
+                    name='John'
+                )
+            ),
+            [obj2, obj4]
+        )
+
+        self.assertListEqual(
+            list(
+                MultipleFieldsModel.objects.filter(
+                    values__hasany=['Lions', 'Jungle'],
+                    name='John',
+                    active=True
+                )
+            ),
+            [obj4]
         )
 
 


### PR DESCRIPTION
BUGFIX: Using __hasany lookup with other filters applied, causes wrong precedence of conditions in WHERE clause.